### PR TITLE
Fix Canvas fence event cleanup

### DIFF
--- a/Core/Canvas.cpp
+++ b/Core/Canvas.cpp
@@ -48,7 +48,12 @@ Core::Canvas::Canvas(Core::Application* pApplication, RECT rectangle)
 
 Core::Canvas::~Canvas()
 {
-	WaitThreadEnd();
+       WaitThreadEnd();
+       if (mFenceEvent != nullptr)
+       {
+               CloseHandle(mFenceEvent);
+               mFenceEvent = nullptr;
+       }
 }
 
 void Core::Canvas::Initialize()


### PR DESCRIPTION
## Summary
- close the Canvas fence event when shutting down

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684a8769cfe0832f983b1225791eef30