### PR TITLE
Fix runtime error message composition in Logger

### DIFF
--- a/Core/Logger.cpp
+++ b/Core/Logger.cpp
@@ -18,11 +18,17 @@ Core::Logger::Logger(const std::string& location)
 
 void Core::Logger::Message(const char* pThisName, Core::MsgType msgType, const std::string& msg)
 {
-	if (msgType == Core::MsgType::Fatal)
-		if (pThisName == nullptr)
-			throw std::runtime_error{ msg };
-		else
-			throw std::runtime_error{ pThisName + ' ' + msg };
+        if (msgType == Core::MsgType::Fatal)
+        {
+                if (pThisName == nullptr)
+                {
+                        throw std::runtime_error{ msg };
+                }
+                else
+                {
+                        throw std::runtime_error{ std::string{ pThisName } + " " + msg };
+                }
+        }
 }
 
 #endif


### PR DESCRIPTION
## Summary
- correct string concatenation when throwing runtime_error

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a97ef4798832fb736ad932aaf2f2c