### PR TITLE
Fix descriptor heap binding

### DIFF
--- a/Core/Canvas.cpp
+++ b/Core/Canvas.cpp
@@ -255,7 +255,22 @@ D3D12_CPU_DESCRIPTOR_HANDLE Core::Canvas::GetCurrentBackBufferView()
 
 Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList5>& Core::Canvas::GetGraphicsCommandList()
 {
-	return mpGraphicsCommandList;
+        return mpGraphicsCommandList;
+}
+
+Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>& Core::Canvas::GetCanvasCbvHeap()
+{
+        return mpCanvasCbvHeap;
+}
+
+UINT Core::Canvas::GetCbvDescriptorSize() const
+{
+        return mCbvDescriptorSize;
+}
+
+Microsoft::WRL::ComPtr<ID3D12Resource>& Core::Canvas::GetCanvasConstantBuffer()
+{
+        return mpCanvasConstantBuffer;
 }
 
 void Core::Canvas::AddMaterial(Core::Material3D* pMaterial)
@@ -270,9 +285,7 @@ void Core::Canvas::AddMaterial(Core::Material2D* pMaterial)
 
 void Core::Canvas::SetDescriptor()
 {
-	ID3D12DescriptorHeap* ppHeaps[]{ mpCanvasCbvHeap.Get() };
-	mpGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
-	mpGraphicsCommandList->SetGraphicsRootDescriptorTable(0, mpCanvasCbvHeap->GetGPUDescriptorHandleForHeapStart());
+        // Descriptor heap is now bound by each ViewC during rendering
 }
 
 void Core::Canvas::Render()

--- a/Core/MeshModelVC.cpp
+++ b/Core/MeshModelVC.cpp
@@ -34,10 +34,13 @@ Core::MeshModelVC::MeshModelVC(const std::string& modelName, const std::string& 
 	, mpObjectCbvHeap{}
 	, mpObjectConstantBuffer{}
 	, mObjectConstantBufferData{}
-	, mpObjectCbvDataBegin{ nullptr }
-	, mpTextureSrvHeaps{}
+        , mpObjectCbvDataBegin{ nullptr }
+        , mpTextureSrvHeaps{}
+        , mpCbvSrvHeap{}
+        , mCbvSrvDescriptorSize{ 0 }
+        , mTextureOffsets{}
 {
-	mObjectConstantBufferData.mShininess = 20.f;
+        mObjectConstantBufferData.mShininess = 20.f;
 }
 
 Core::MeshModelVC::~MeshModelVC()
@@ -203,8 +206,8 @@ void Core::MeshModelVC::Initialize()
 		mVertexBufferView.StrideInBytes = UINT(layoutSize);
 		mVertexBufferView.SizeInBytes = vertexBufferSize;
 	}
-	{
-		const UINT objectConstantBufferSize{ sizeof(Core::MeshVCConstantBuffer) };
+        {
+                const UINT objectConstantBufferSize{ sizeof(Core::MeshVCConstantBuffer) };
 
 		D3D12_HEAP_PROPERTIES heapProp{ CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD) };
 		D3D12_RESOURCE_DESC resDesc{ CD3DX12_RESOURCE_DESC::Buffer(objectConstantBufferSize) };
@@ -222,10 +225,32 @@ void Core::MeshModelVC::Initialize()
 		pDevice->CreateConstantBufferView(&cbvDesc, mpObjectCbvHeap->GetCPUDescriptorHandleForHeapStart());
 
 		CD3DX12_RANGE readRange(0, 0);
-		mpObject->GetScene()->GetApplication()->ThrowIfFailed(mpObjectConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&mpObjectCbvDataBegin)));
-		memcpy(mpObjectCbvDataBegin, &mObjectConstantBufferData, sizeof(mObjectConstantBufferData));
-	}
-	mIsInitialized = true;
+                mpObject->GetScene()->GetApplication()->ThrowIfFailed(mpObjectConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&mpObjectCbvDataBegin)));
+                memcpy(mpObjectCbvDataBegin, &mObjectConstantBufferData, sizeof(mObjectConstantBufferData));
+        }
+
+        mCbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+        {
+                D3D12_DESCRIPTOR_HEAP_DESC heapDesc{};
+                heapDesc.NumDescriptors = 1 + 1 + UINT(mpTextureSrvHeaps.size());
+                heapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+                heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+                mpObject->GetScene()->GetApplication()->ThrowIfFailed(pDevice->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(&mpCbvSrvHeap)));
+
+                D3D12_CPU_DESCRIPTOR_HANDLE destHandle{ mpCbvSrvHeap->GetCPUDescriptorHandleForHeapStart() };
+                destHandle.ptr += mCbvSrvDescriptorSize; // index 1 for object CBV
+                pDevice->CopyDescriptorsSimple(1, destHandle, mpObjectCbvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+
+                UINT offset{ 2 };
+                for (auto& pair : mpTextureSrvHeaps)
+                {
+                        D3D12_CPU_DESCRIPTOR_HANDLE dest{ CD3DX12_CPU_DESCRIPTOR_HANDLE(mpCbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), offset, mCbvSrvDescriptorSize) };
+                        pDevice->CopyDescriptorsSimple(1, dest, pair.second->GetCPUDescriptorHandleForHeapStart(), D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+                        mTextureOffsets[pair.first] = offset;
+                        ++offset;
+                }
+        }
+        mIsInitialized = true;
 }
 
 void Core::MeshModelVC::Update(float delta)
@@ -247,11 +272,21 @@ bool Core::MeshModelVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMateria
 	if (!mIsActive)
 		return false;
 
-	auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
+        auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
+        auto pDevice{ mpObject->GetScene()->GetApplication()->GetDevice() };
 
-	UINT dsTable{ 1 };
-	SetDescTableObjectConstants(pCanvas, dsTable);
-	SetDescTableTextures(pCanvas, dsTable);
+        // Write canvas constant buffer view into local heap
+        D3D12_CONSTANT_BUFFER_VIEW_DESC canvasCbv{};
+        canvasCbv.BufferLocation = pCanvas->GetCanvasConstantBuffer()->GetGPUVirtualAddress();
+        canvasCbv.SizeInBytes = sizeof(Core::CanvasConstantBuffer);
+        pDevice->CreateConstantBufferView(&canvasCbv, mpCbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
+
+        ID3D12DescriptorHeap* ppHeaps[]{ mpCbvSrvHeap.Get() };
+        pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+
+        UINT dsTable{ 1 };
+        SetDescTableObjectConstants(pCanvas, dsTable);
+        SetDescTableTextures(pCanvas, dsTable);
 	pGraphicsCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 	pGraphicsCommandList->IASetIndexBuffer(&mIndexBufferView);
 	pGraphicsCommandList->IASetVertexBuffers(0, 1, &mVertexBufferView);
@@ -278,24 +313,21 @@ void Core::MeshModelVC::SetDescTableObjectConstants(Core::Canvas* pCanvas, UINT&
 	DirectX::XMStoreFloat4x4(&mObjectConstantBufferData.mWorldViewProj, wvp);
 
 	memcpy(mpObjectCbvDataBegin, &mObjectConstantBufferData, sizeof(mObjectConstantBufferData));
-	{
-		ID3D12DescriptorHeap* ppHeaps[]{ mpObjectCbvHeap.Get() };
-		pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
-		pGraphicsCommandList->SetGraphicsRootDescriptorTable(dsTable, mpObjectCbvHeap->GetGPUDescriptorHandleForHeapStart());
-	}
-	++dsTable;
+        {
+                D3D12_GPU_DESCRIPTOR_HANDLE handle{ CD3DX12_GPU_DESCRIPTOR_HANDLE(mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart(), 1, mCbvSrvDescriptorSize) };
+                pGraphicsCommandList->SetGraphicsRootDescriptorTable(dsTable, handle);
+        }
+        ++dsTable;
 }
 
 void Core::MeshModelVC::SetDescTableTextures(Core::Canvas* pCanvas, UINT& dsTable)
 {
 	auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
 
-	for (auto& pair : mpTextureSrvHeaps)
-	{
-		ID3D12DescriptorHeap* ppHeaps[]{ pair.second.Get() };
-		pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
-		//CD3DX12_GPU_DESCRIPTOR_HANDLE tex{ pair.second->GetGPUDescriptorHandleForHeapStart() };
-		pGraphicsCommandList->SetGraphicsRootDescriptorTable(dsTable, pair.second->GetGPUDescriptorHandleForHeapStart());
-		++dsTable;
-	}
+        for (auto& pair : mTextureOffsets)
+        {
+                D3D12_GPU_DESCRIPTOR_HANDLE tex{ CD3DX12_GPU_DESCRIPTOR_HANDLE(mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart(), pair.second, mCbvSrvDescriptorSize) };
+                pGraphicsCommandList->SetGraphicsRootDescriptorTable(dsTable, tex);
+                ++dsTable;
+        }
 }

--- a/Core/MeshVC.cpp
+++ b/Core/MeshVC.cpp
@@ -5,6 +5,7 @@
 #include "Object.h"
 #include "Scene.h"
 #include "CameraRMC.h"
+#include "Canvas.h"
 
 using namespace Ion;
 
@@ -82,8 +83,8 @@ void Core::MeshVC::Initialize()
 		mVertexBufferView.StrideInBytes = sizeof(Core::VertexPNC);
 		mVertexBufferView.SizeInBytes = mMaxVertices * sizeof(Core::VertexPNC);
 	}
-	{
-		const UINT objectConstantBufferSize{ sizeof(Core::MeshVCConstantBuffer) };
+        {
+                const UINT objectConstantBufferSize{ sizeof(Core::MeshVCConstantBuffer) };
 
 		D3D12_HEAP_PROPERTIES heapProp{ CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD) };
 		D3D12_RESOURCE_DESC resDesc{ CD3DX12_RESOURCE_DESC::Buffer(objectConstantBufferSize) };
@@ -101,10 +102,22 @@ void Core::MeshVC::Initialize()
 		pDevice->CreateConstantBufferView(&cbvDesc, mpObjectCbvHeap->GetCPUDescriptorHandleForHeapStart());
 
 		CD3DX12_RANGE readRange(0, 0);
-		mpObject->GetScene()->GetApplication()->ThrowIfFailed(mpObjectConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&mpObjectCbvDataBegin)));
-		memcpy(mpObjectCbvDataBegin, &mObjectConstantBufferData, sizeof(mObjectConstantBufferData));
-	}
-	mIsInitialized = true;
+                mpObject->GetScene()->GetApplication()->ThrowIfFailed(mpObjectConstantBuffer->Map(0, &readRange, reinterpret_cast<void**>(&mpObjectCbvDataBegin)));
+                memcpy(mpObjectCbvDataBegin, &mObjectConstantBufferData, sizeof(mObjectConstantBufferData));
+        }
+
+        mCbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+        {
+                D3D12_DESCRIPTOR_HEAP_DESC heapDesc{};
+                heapDesc.NumDescriptors = 2; // canvas + object
+                heapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+                heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+                mpObject->GetScene()->GetApplication()->ThrowIfFailed(pDevice->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(&mpCbvSrvHeap)));
+
+                D3D12_CPU_DESCRIPTOR_HANDLE dest{ CD3DX12_CPU_DESCRIPTOR_HANDLE(mpCbvSrvHeap->GetCPUDescriptorHandleForHeapStart(), 1, mCbvSrvDescriptorSize) };
+                pDevice->CopyDescriptorsSimple(1, dest, mpObjectCbvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+        }
+        mIsInitialized = true;
 }
 
 void Core::MeshVC::Update(float delta)
@@ -151,12 +164,19 @@ bool Core::MeshVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMaterial, fl
 	DirectX::XMStoreFloat4x4(&mObjectConstantBufferData.mWorld , world);
 	DirectX::XMStoreFloat4x4(&mObjectConstantBufferData.mWorldViewProj, wvp);
 
-	memcpy(mpObjectCbvDataBegin, &mObjectConstantBufferData, sizeof(mObjectConstantBufferData));
-	{
-		ID3D12DescriptorHeap* ppHeaps[]{ mpObjectCbvHeap.Get() };
-		pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
-		pGraphicsCommandList->SetGraphicsRootDescriptorTable(1, mpObjectCbvHeap->GetGPUDescriptorHandleForHeapStart());
-	}
+        memcpy(mpObjectCbvDataBegin, &mObjectConstantBufferData, sizeof(mObjectConstantBufferData));
+
+        D3D12_CONSTANT_BUFFER_VIEW_DESC canvasCbv{};
+        canvasCbv.BufferLocation = pCanvas->GetCanvasConstantBuffer()->GetGPUVirtualAddress();
+        canvasCbv.SizeInBytes = sizeof(Core::CanvasConstantBuffer);
+        pDevice->CreateConstantBufferView(&canvasCbv, mpCbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
+
+        ID3D12DescriptorHeap* ppHeaps[]{ mpCbvSrvHeap.Get() };
+        pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+
+        D3D12_GPU_DESCRIPTOR_HANDLE cbvHandle{ CD3DX12_GPU_DESCRIPTOR_HANDLE(mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart(), 1, mCbvSrvDescriptorSize) };
+        pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
+        pGraphicsCommandList->SetGraphicsRootDescriptorTable(1, cbvHandle);
 
 	pGraphicsCommandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 	pGraphicsCommandList->IASetVertexBuffers(0, 1, &mVertexBufferView);

--- a/Core/include/Canvas.h
+++ b/Core/include/Canvas.h
@@ -29,8 +29,12 @@ namespace Ion
 			Core::Object* GetCamera();
 			float GetRatio();
 
-			D3D12_CPU_DESCRIPTOR_HANDLE GetCurrentBackBufferView();
-			Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList5>& GetGraphicsCommandList();
+                       D3D12_CPU_DESCRIPTOR_HANDLE GetCurrentBackBufferView();
+                       Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList5>& GetGraphicsCommandList();
+
+                       Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>& GetCanvasCbvHeap();
+                       UINT GetCbvDescriptorSize() const;
+                       Microsoft::WRL::ComPtr<ID3D12Resource>& GetCanvasConstantBuffer();
 
 			void AddMaterial(Core::Material3D* pMaterial);
 			void AddMaterial(Core::Material2D* pMaterial);

--- a/Core/include/MeshModelVC.h
+++ b/Core/include/MeshModelVC.h
@@ -59,7 +59,11 @@ namespace Ion
 
 			std::vector<std::string> mTextureNames;
 			std::unordered_map<Core::TextureType, Core::Texture*> mpTextures;
-			std::unordered_map<Core::TextureType, Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>> mpTextureSrvHeaps;
+                       std::unordered_map<Core::TextureType, Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>> mpTextureSrvHeaps;
+
+                       Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mpCbvSrvHeap;
+                       UINT mCbvSrvDescriptorSize;
+                       std::unordered_map<Core::TextureType, UINT> mTextureOffsets;
 
 			void SetDescTableObjectConstants(Core::Canvas* pCanvas, UINT& dsTable);
 			void SetDescTableTextures(Core::Canvas* pCanvas, UINT& dsTable);

--- a/Core/include/MeshVC.h
+++ b/Core/include/MeshVC.h
@@ -45,10 +45,13 @@ namespace Ion
 			D3D12_VERTEX_BUFFER_VIEW mVertexBufferView;
 			UINT8* mpVertexDataBegin;
 
-			Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mpObjectCbvHeap;
-			Microsoft::WRL::ComPtr<ID3D12Resource> mpObjectConstantBuffer;
-			Core::MeshVCConstantBuffer mObjectConstantBufferData;
-			UINT8* mpObjectCbvDataBegin;
-		};
-	}
+                       Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mpObjectCbvHeap;
+                       Microsoft::WRL::ComPtr<ID3D12Resource> mpObjectConstantBuffer;
+                       Core::MeshVCConstantBuffer mObjectConstantBufferData;
+                       UINT8* mpObjectCbvDataBegin;
+
+                       Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mpCbvSrvHeap;
+                       UINT mCbvSrvDescriptorSize;
+                };
+        }
 }


### PR DESCRIPTION
## Summary
- add Canvas constant buffer accessor
- write canvas CBV directly in MeshModelVC and MeshVC instead of copying

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa08eeab8832f8cb77c5f668d1d70