### PR TITLE
Add validation for D3D12 descriptor resources

### DIFF
--- a/Core/MeshModelVC.cpp
+++ b/Core/MeshModelVC.cpp
@@ -273,6 +273,15 @@ bool Core::MeshModelVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMateria
 		return false;
 
         auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
+        if (!pGraphicsCommandList || !mpCbvSrvHeap || !mpObjectCbvDataBegin)
+        {
+#ifdef ION_LOGGER
+                mpObject->GetScene()->GetApplication()->GetServiceLocator().GetLogger()->Message(
+                        typeid(this).name(), Core::MsgType::Fatal,
+                        "ModelVC.Render() invalid command list or descriptor heap");
+#endif
+                return false;
+        }
         auto pDevice{ mpObject->GetScene()->GetApplication()->GetDevice() };
 
         // Write canvas constant buffer view into local heap
@@ -296,7 +305,16 @@ bool Core::MeshModelVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMateria
 
 void Core::MeshModelVC::SetDescTableObjectConstants(Core::Canvas* pCanvas, UINT& dsTable)
 {
-	auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
+        auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
+        if (!pGraphicsCommandList || !mpCbvSrvHeap || !mpObjectCbvDataBegin)
+        {
+#ifdef ION_LOGGER
+                mpObject->GetScene()->GetApplication()->GetServiceLocator().GetLogger()->Message(
+                        typeid(this).name(), Core::MsgType::Fatal,
+                        "ModelVC.SetDescTableObjectConstants invalid state");
+#endif
+                return;
+        }
 
 	DirectX::XMMATRIX world{ DirectX::XMMatrixIdentity() };
 	Core::InstancedTransformMC* pInstancedTransformMC{ mpObject->GetModelC<InstancedTransformMC>() };
@@ -322,7 +340,16 @@ void Core::MeshModelVC::SetDescTableObjectConstants(Core::Canvas* pCanvas, UINT&
 
 void Core::MeshModelVC::SetDescTableTextures(Core::Canvas* pCanvas, UINT& dsTable)
 {
-	auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
+        auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
+        if (!pGraphicsCommandList || !mpCbvSrvHeap)
+        {
+#ifdef ION_LOGGER
+                mpObject->GetScene()->GetApplication()->GetServiceLocator().GetLogger()->Message(
+                        typeid(this).name(), Core::MsgType::Fatal,
+                        "ModelVC.SetDescTableTextures invalid state");
+#endif
+                return;
+        }
 
         for (auto& pair : mTextureOffsets)
         {

--- a/Core/MeshVC.cpp
+++ b/Core/MeshVC.cpp
@@ -151,11 +151,21 @@ bool Core::MeshVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMaterial, fl
 	if (mVertexCount == 0)
 		return false;
 
-	Core::Application* pApplication{ mpObject->GetScene()->GetApplication() };
-	auto pDxgiFactory{ pApplication->GetDxgiFactory() };
-	auto pDevice{ pApplication->GetDevice() };
-	auto pCmdQueue{ pApplication->GetCommandQueue() };
-	auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
+        Core::Application* pApplication{ mpObject->GetScene()->GetApplication() };
+        auto pDxgiFactory{ pApplication->GetDxgiFactory() };
+        auto pDevice{ pApplication->GetDevice() };
+        auto pCmdQueue{ pApplication->GetCommandQueue() };
+        auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
+
+        if (!pGraphicsCommandList || !mpCbvSrvHeap || !mpObjectCbvDataBegin)
+        {
+#ifdef ION_LOGGER
+                mpObject->GetScene()->GetApplication()->GetServiceLocator().GetLogger()->Message(
+                        typeid(this).name(), Core::MsgType::Fatal,
+                        "MeshVC.Render() invalid command list or descriptor heap");
+#endif
+                return false;
+        }
 
 	DirectX::XMMATRIX world{ DirectX::XMLoadFloat4x4(&mpObject->GetModelC<Core::TransformMC>()->GetWorld()) };
 	const DirectX::XMMATRIX viewProjection{ DirectX::XMLoadFloat4x4(&pCanvas->GetCamera()->GetModelC<Core::CameraRMC>()->GetViewProjection()) };


### PR DESCRIPTION
## Summary
- prevent crashes if descriptor resources or command lists are invalid
- add checks in `MeshVC` and `MeshModelVC` before using descriptor heaps

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684aa67f22ec832fbbb60f1ce7430836