### PR TITLE
Switch bones CBV to root descriptor

### DIFF
--- a/Core/Shaders/PosNormTanTex_aAN_rs.hlsl
+++ b/Core/Shaders/PosNormTanTex_aAN_rs.hlsl
@@ -6,7 +6,7 @@
   "DENY_GEOMETRY_SHADER_ROOT_ACCESS), " \
 "DescriptorTable(CBV(b0, numDescriptors = 1), visibility = SHADER_VISIBILITY_ALL), " \
 "DescriptorTable(CBV(b1, numDescriptors = 1), visibility = SHADER_VISIBILITY_ALL), " \
-"DescriptorTable(CBV(b2, numDescriptors = 1), visibility = SHADER_VISIBILITY_ALL), " \
+"CBV(b2, visibility = SHADER_VISIBILITY_ALL), " \
 "DescriptorTable(SRV(t0), visibility = SHADER_VISIBILITY_PIXEL), " \
 "DescriptorTable(SRV(t1), visibility = SHADER_VISIBILITY_PIXEL), " \
 "StaticSampler(s0, Filter = FILTER_MIN_MAG_MIP_LINEAR, AddressU = TEXTURE_ADDRESS_WRAP, AddressV = TEXTURE_ADDRESS_WRAP, AddressW = TEXTURE_ADDRESS_WRAP)"

--- a/Core/Shaders/PosNormTanTex_iaAN_rs.hlsl
+++ b/Core/Shaders/PosNormTanTex_iaAN_rs.hlsl
@@ -6,7 +6,7 @@
   "DENY_GEOMETRY_SHADER_ROOT_ACCESS), " \
 "DescriptorTable(CBV(b0, numDescriptors = 1), visibility = SHADER_VISIBILITY_ALL), " \
 "DescriptorTable(CBV(b1, numDescriptors = 1), visibility = SHADER_VISIBILITY_ALL), " \
-"DescriptorTable(CBV(b2, numDescriptors = 1), visibility = SHADER_VISIBILITY_ALL), " \
+"CBV(b2, visibility = SHADER_VISIBILITY_ALL), " \
 "DescriptorTable(SRV(t0), visibility = SHADER_VISIBILITY_PIXEL), " \
 "DescriptorTable(SRV(t1), visibility = SHADER_VISIBILITY_PIXEL), " \
 "SRV(t9), " \

--- a/Core/include/AnimatedMVC.h
+++ b/Core/include/AnimatedMVC.h
@@ -46,10 +46,9 @@ namespace Ion
 				mIsAnimating,
 				mIsClipSet;
 
-			Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mpBonesCbvHeap;
-			Microsoft::WRL::ComPtr<ID3D12Resource> mpBonesConstantBuffer;
-			Core::BonesConstantBuffer* mpBonesConstantBufferData;
-			UINT8* mpBonesCbvDataBegin;
-		};
+                        Microsoft::WRL::ComPtr<ID3D12Resource> mpBonesConstantBuffer;
+                        Core::BonesConstantBuffer* mpBonesConstantBufferData;
+                        UINT8* mpBonesCbvDataBegin;
+                };
 	}
 }

--- a/Core/include/InstancedAnimatedMVC.h
+++ b/Core/include/InstancedAnimatedMVC.h
@@ -57,10 +57,9 @@ namespace Ion
 				mIsAnimating,
 				mIsClipSet;
 
-			Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mpBonesCbvHeap;
-			Microsoft::WRL::ComPtr<ID3D12Resource> mpBonesConstantBuffer;
-			Core::BonesConstantBuffer* mpBonesConstantBufferData;
-			UINT8* mpBonesCbvDataBegin;
-		};
+                        Microsoft::WRL::ComPtr<ID3D12Resource> mpBonesConstantBuffer;
+                        Core::BonesConstantBuffer* mpBonesConstantBufferData;
+                        UINT8* mpBonesCbvDataBegin;
+                };
 	}
 }


### PR DESCRIPTION
## Summary
- use a root CBV for animated bones instead of a descriptor heap
- drop bones descriptor heap and update initialization
- adjust shader root signatures for new root CBV

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac12ca5f8832f8cb899ef560f0943