### PR TITLE
Fix missing canvas constant buffer binding

### DIFF
--- a/Core/AnimatedMVC.cpp
+++ b/Core/AnimatedMVC.cpp
@@ -155,6 +155,8 @@ bool Core::AnimatedMVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMateria
         {
                 ID3D12DescriptorHeap* ppHeaps[]{ mpCbvSrvHeap.Get() };
                 pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+                // Bind canvas constant buffer descriptor table
+                pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
         }
         SetDescTableObjectConstants(pCanvas, dsTable);
 

--- a/Core/InstancedAnimatedMVC.cpp
+++ b/Core/InstancedAnimatedMVC.cpp
@@ -197,6 +197,8 @@ bool Core::InstancedAnimatedMVC::Render(Core::Canvas* pCanvas, Core::Material3D*
         {
                 ID3D12DescriptorHeap* ppHeaps[]{ mpCbvSrvHeap.Get() };
                 pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+                // Bind canvas constant buffer descriptor table
+                pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
         }
         SetDescTableObjectConstants(pCanvas, dsTable);
 

--- a/Core/InstancedMVC.cpp
+++ b/Core/InstancedMVC.cpp
@@ -107,6 +107,9 @@ bool Core::InstancedMVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMateri
         ID3D12DescriptorHeap* ppHeaps[]{ mpCbvSrvHeap.Get() };
         pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
+        // Bind canvas constant buffer descriptor table
+        pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
+
         UINT dsTable{ 1 };
         SetDescTableObjectConstants(pCanvas, dsTable);
         SetDescTableTextures(pCanvas, dsTable);

--- a/Core/MeshModelVC.cpp
+++ b/Core/MeshModelVC.cpp
@@ -293,6 +293,9 @@ bool Core::MeshModelVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMateria
         ID3D12DescriptorHeap* ppHeaps[]{ mpCbvSrvHeap.Get() };
         pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
+        // Bind canvas constant buffer descriptor table
+        pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
+
         UINT dsTable{ 1 };
         SetDescTableObjectConstants(pCanvas, dsTable);
         SetDescTableTextures(pCanvas, dsTable);


### PR DESCRIPTION
## Summary
- bind the canvas constant buffer table before setting other descriptor tables in all mesh view components

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ad1b25618832fb374c635d1ece7d8