### PR TITLE
Use single descriptor heap

### DIFF
--- a/Core/AnimatedMVC.cpp
+++ b/Core/AnimatedMVC.cpp
@@ -150,14 +150,10 @@ bool Core::AnimatedMVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMateria
 
         auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
 
+        auto pApplication{ mpObject->GetScene()->GetApplication() };
         UINT dsTable{ 1 };
-        // Set the main CBV/SRV heap before using any of its handles
-        {
-                ID3D12DescriptorHeap* ppHeaps[]{ mpCbvSrvHeap.Get() };
-                pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
-                // Bind canvas constant buffer descriptor table
-                pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
-        }
+        // Bind canvas constant buffer descriptor table
+        pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, pApplication->GetGpuHandle(mCbvSrvOffset));
         SetDescTableObjectConstants(pCanvas, dsTable);
 
         // Upload bone matrices and bind as root CBV

--- a/Core/InstancedAnimatedMVC.cpp
+++ b/Core/InstancedAnimatedMVC.cpp
@@ -192,14 +192,10 @@ bool Core::InstancedAnimatedMVC::Render(Core::Canvas* pCanvas, Core::Material3D*
 
         auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
 
+        auto pApplication{ mpObject->GetScene()->GetApplication() };
         UINT dsTable{ 1 };
-        // Use main CBV/SRV heap before writing object constants
-        {
-                ID3D12DescriptorHeap* ppHeaps[]{ mpCbvSrvHeap.Get() };
-                pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
-                // Bind canvas constant buffer descriptor table
-                pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
-        }
+        // Bind canvas constant buffer descriptor table
+        pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, pApplication->GetGpuHandle(mCbvSrvOffset));
         SetDescTableObjectConstants(pCanvas, dsTable);
 
         // Upload bones and bind as root CBV

--- a/Core/InstancedMVC.cpp
+++ b/Core/InstancedMVC.cpp
@@ -86,7 +86,8 @@ bool Core::InstancedMVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMateri
 		return false;
 
         auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
-        if (!pGraphicsCommandList || !mpCbvSrvHeap || !mpObjectCbvDataBegin)
+        auto pApplication{ mpObject->GetScene()->GetApplication() };
+        if (!pGraphicsCommandList || !mpObjectCbvDataBegin)
         {
 #ifdef ION_LOGGER
                 mpObject->GetScene()->GetApplication()->GetServiceLocator().GetLogger()->Message(
@@ -102,13 +103,10 @@ bool Core::InstancedMVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMateri
         D3D12_CONSTANT_BUFFER_VIEW_DESC canvasCbv{};
         canvasCbv.BufferLocation = pCanvas->GetCanvasConstantBuffer()->GetGPUVirtualAddress();
         canvasCbv.SizeInBytes = sizeof(Core::CanvasConstantBuffer);
-        pDevice->CreateConstantBufferView(&canvasCbv, mpCbvSrvHeap->GetCPUDescriptorHandleForHeapStart());
-
-        ID3D12DescriptorHeap* ppHeaps[]{ mpCbvSrvHeap.Get() };
-        pGraphicsCommandList->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+        pDevice->CreateConstantBufferView(&canvasCbv, pApplication->GetCpuHandle(mCbvSrvOffset));
 
         // Bind canvas constant buffer descriptor table
-        pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, mpCbvSrvHeap->GetGPUDescriptorHandleForHeapStart());
+        pGraphicsCommandList->SetGraphicsRootDescriptorTable(0, pApplication->GetGpuHandle(mCbvSrvOffset));
 
         UINT dsTable{ 1 };
         SetDescTableObjectConstants(pCanvas, dsTable);

--- a/Core/Material3D.cpp
+++ b/Core/Material3D.cpp
@@ -202,9 +202,7 @@ void Core::Material3D::Render(Core::Canvas* pCanvas)
 	pGraphicsCommandList->SetPipelineState(mpPipelineState.Get());
 	pGraphicsCommandList->SetGraphicsRootSignature(mpRootSignature.Get());
 
-	pCanvas->SetDescriptor();
-
-	std::multimap<long long, Core::ViewCCube>& cubes{ mpCanvasCubes[pCanvas] };
+        std::multimap<long long, Core::ViewCCube>& cubes{ mpCanvasCubes[pCanvas] };
 	for (auto& cube : cubes)
 		cube.second.Render(pCanvas, this);
 }

--- a/Core/doc/ViewST.cd
+++ b/Core/doc/ViewST.cd
@@ -129,7 +129,6 @@
       <Field Name="mIsInitialized" Hidden="true" />
       <Field Name="mpCamera" Hidden="true" />
       <Field Name="mpCanvasCbvDataBegin" Hidden="true" />
-      <Field Name="mpCanvasCbvHeap" Hidden="true" />
       <Field Name="mpCanvasConstantBuffer" Hidden="true" />
       <Field Name="mpCommandAllocator" Hidden="true" />
       <Field Name="mpConditionVar" Hidden="true" />

--- a/Core/include/Application.h
+++ b/Core/include/Application.h
@@ -44,8 +44,12 @@ namespace Ion
 			LRESULT WindowsProcedure(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 			const Microsoft::WRL::ComPtr<IDXGIFactory5>& GetDxgiFactory();
 			const Microsoft::WRL::ComPtr<ID3D12Device5>& GetDevice();
-			const Microsoft::WRL::ComPtr<ID3D12CommandQueue>& GetCommandQueue();
-			physx::PxPhysics* GetPxPhysics();
+                        const Microsoft::WRL::ComPtr<ID3D12CommandQueue>& GetCommandQueue();
+                        Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>& GetGlobalCbvSrvHeap();
+                        UINT AllocateDescriptors(UINT count = 1);
+                        D3D12_CPU_DESCRIPTOR_HANDLE GetCpuHandle(UINT index);
+                        D3D12_GPU_DESCRIPTOR_HANDLE GetGpuHandle(UINT index);
+                        physx::PxPhysics* GetPxPhysics();
 			physx::PxCooking* GetPxCooking();
 			const physx::PxTolerancesScale& GetToleranceScale();
 			Core::ServiceLocator& GetServiceLocator();
@@ -74,8 +78,11 @@ namespace Ion
 			Microsoft::WRL::ComPtr<IDXGIFactory5> mpDxgiFactory;
 			Microsoft::WRL::ComPtr<ID3D12Device5> mpD3d12Device;
 			Microsoft::WRL::ComPtr<IDXGIDevice1> mpDxgiDevice;
-			Microsoft::WRL::ComPtr<ID3D12CommandQueue> mpCommandQueue;
-			physx::PxPhysics* mpPhysics;
+                        Microsoft::WRL::ComPtr<ID3D12CommandQueue> mpCommandQueue;
+                        Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mpGlobalCbvSrvHeap;
+                        UINT mGlobalCbvSrvDescriptorSize;
+                        UINT mNextDescriptorIndex;
+                        physx::PxPhysics* mpPhysics;
 			physx::PxTolerancesScale mPxToleranceScale;
 			physx::PxIonAllocatorCallback mIonAllocatorCallback;
 			physx::PxIonErrorCallback mIonErrorCallback;

--- a/Core/include/Canvas.h
+++ b/Core/include/Canvas.h
@@ -32,13 +32,11 @@ namespace Ion
                        D3D12_CPU_DESCRIPTOR_HANDLE GetCurrentBackBufferView();
                        Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList5>& GetGraphicsCommandList();
 
-                       Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>& GetCanvasCbvHeap();
                        UINT GetCbvDescriptorSize() const;
                        Microsoft::WRL::ComPtr<ID3D12Resource>& GetCanvasConstantBuffer();
 
 			void AddMaterial(Core::Material3D* pMaterial);
 			void AddMaterial(Core::Material2D* pMaterial);
-			void SetDescriptor();
 			void WaitForPreviousFrame();
 
 			void RunThread(std::condition_variable* pConditionVar, std::mutex* pMutex);
@@ -58,9 +56,8 @@ namespace Ion
 				mpRenderTargets[mBackBufferCount],
 				mpDepthStencilBuffer;
 			Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>
-				mpRtvHeap,
-				mpDsvHeap,
-				mpCanvasCbvHeap;
+                                mpRtvHeap,
+                                mpDsvHeap;
 			Microsoft::WRL::ComPtr<ID3D12CommandAllocator> mpCommandAllocator;
 			Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList5> mpGraphicsCommandList;
 			int mCurrentBackBuffer;
@@ -74,7 +71,8 @@ namespace Ion
 			Microsoft::WRL::ComPtr<ID3D12Fence> mpFence;
 			UINT64 mFenceValue;
 			Microsoft::WRL::ComPtr<ID3D12Resource> mpCanvasConstantBuffer;
-			UINT8* mpCanvasCbvDataBegin;
+                        UINT8* mpCanvasCbvDataBegin;
+                        UINT mCanvasCbvOffset;
 			Core::CanvasConstantBuffer mCanvasConstantBufferData;
 			std::set<Core::Material3D*> mpMaterials3D;
 			std::set<Core::Material2D*> mpMaterials2D;

--- a/Core/include/MeshModelVC.h
+++ b/Core/include/MeshModelVC.h
@@ -61,7 +61,7 @@ namespace Ion
 			std::unordered_map<Core::TextureType, Core::Texture*> mpTextures;
                        std::unordered_map<Core::TextureType, Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>> mpTextureSrvHeaps;
 
-                       Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mpCbvSrvHeap;
+                       UINT mCbvSrvOffset;
                        UINT mCbvSrvDescriptorSize;
                        std::unordered_map<Core::TextureType, UINT> mTextureOffsets;
 

--- a/Core/include/MeshVC.h
+++ b/Core/include/MeshVC.h
@@ -50,7 +50,7 @@ namespace Ion
                        Core::MeshVCConstantBuffer mObjectConstantBufferData;
                        UINT8* mpObjectCbvDataBegin;
 
-                       Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mpCbvSrvHeap;
+                       UINT mCbvSrvOffset;
                        UINT mCbvSrvDescriptorSize;
                 };
         }

--- a/Core/include/TerrainVC.h
+++ b/Core/include/TerrainVC.h
@@ -64,7 +64,7 @@ namespace Ion
                        std::unordered_map<Core::TextureType, Core::Texture*> mpTextures;
                        std::unordered_map<Core::TextureType, Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>> mpTextureSrvHeaps;
 
-                       Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mpCbvSrvHeap;
+                       UINT mCbvSrvOffset;
                        UINT mCbvSrvDescriptorSize;
                        std::unordered_map<Core::TextureType, UINT> mTextureOffsets;
 


### PR DESCRIPTION
## Summary
- allocate one global shader-visible CBV/SRV heap at startup
- give `Application` helper methods for descriptor allocation
- bind the heap once per command list in `Canvas::Render`
- sub-allocate descriptors for each view component
- update rendering code to use global handles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ad8405ee0832fbd75964aa57b725a