### PR TITLE
Fix undefined variable in MeshModelVC

### DIFF
--- a/Core/MeshModelVC.cpp
+++ b/Core/MeshModelVC.cpp
@@ -301,6 +301,7 @@ bool Core::MeshModelVC::Render(Core::Canvas* pCanvas, Core::Material3D* pMateria
 void Core::MeshModelVC::SetDescTableObjectConstants(Core::Canvas* pCanvas, UINT& dsTable)
 {
         auto pGraphicsCommandList{ pCanvas->GetGraphicsCommandList() };
+       auto pApplication{ mpObject->GetScene()->GetApplication() };
         if (!pGraphicsCommandList || !mpObjectCbvDataBegin)
         {
 #ifdef ION_LOGGER


### PR DESCRIPTION
## Summary
- declare `pApplication` in `SetDescTableObjectConstants` before use

## Testing
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684ae1cbe26c832f881d91438e23ffcd