### PR TITLE
Ensure consistent texture descriptor order

### DIFF
--- a/Core/MeshModelVC.cpp
+++ b/Core/MeshModelVC.cpp
@@ -12,6 +12,7 @@
 #include "MeshModelResource.h"
 #include "TextureResource.h"
 #include "Texture.h"
+#include <algorithm>
 #include "Model.h"
 
 using namespace Ion;
@@ -234,8 +235,9 @@ void Core::MeshModelVC::Initialize()
         mCbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
         mCbvSrvOffset = pApplication->AllocateDescriptors(1 + 1 + UINT(mpTextureSrvHeaps.size()));
         {
-                D3D12_CPU_DESCRIPTOR_HANDLE destHandle{ pApplication->GetCpuHandle(mCbvSrvOffset + 1) };
-                pDevice->CopyDescriptorsSimple(1, destHandle, mpObjectCbvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+               std::sort(mTextureTypeOrder.begin(), mTextureTypeOrder.end(), [](Core::TextureType a, Core::TextureType b) { return int(a) < int(b); });
+               D3D12_CPU_DESCRIPTOR_HANDLE destHandle{ pApplication->GetCpuHandle(mCbvSrvOffset + 1) };
+               pDevice->CopyDescriptorsSimple(1, destHandle, mpObjectCbvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
                 UINT offset{ 2 };
                 for (auto textureType : mTextureTypeOrder)

--- a/Core/TerrainVC.cpp
+++ b/Core/TerrainVC.cpp
@@ -7,6 +7,7 @@
 #include "CameraRMC.h"
 #include "TextureResource.h"
 #include "Texture.h"
+#include <algorithm>
 
 using namespace Ion;
 
@@ -310,6 +311,7 @@ void Core::TerrainVC::Initialize()
        mCbvSrvDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
        mCbvSrvOffset = pApplication->AllocateDescriptors(1 + 1 + UINT(mpTextureSrvHeaps.size()));
        {
+               std::sort(mTextureTypeOrder.begin(), mTextureTypeOrder.end(), [](Core::TextureType a, Core::TextureType b) { return int(a) < int(b); });
                D3D12_CPU_DESCRIPTOR_HANDLE dest{ pApplication->GetCpuHandle(mCbvSrvOffset + 1) };
                pDevice->CopyDescriptorsSimple(1, dest, mpObjectCbvHeap->GetCPUDescriptorHandleForHeapStart(), D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 


### PR DESCRIPTION
## Summary
- include `<algorithm>` in texture view components
- sort texture binding order before copying descriptors for MeshModelVC and TerrainVC

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ae9312be4832fada4e8ca0dcef32d